### PR TITLE
Hacer mas impredecible la carrera de camellos

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ Solo abre `index.html` en tu navegador. Navega entre secciones utilizando el men
 - próximamente más misterios
 
 ## Carrera de camellos
-El minijuego de camellos ahora es más impredecible: cada camello puede avanzar o retroceder de forma torpe antes de llegar a la meta.
+El minijuego de camellos ahora es más impredecible: cada camello puede avanzar o retroceder de forma torpe antes de llegar a la meta, y a veces uno recibe una ventaja o desventaja para que ningún color domine siempre.

--- a/views/home.html
+++ b/views/home.html
@@ -629,18 +629,30 @@
         raceTrack.style.display = 'block';
         camels.forEach(c => c.style.right = '0');
         positions = camels.map(() => 0);
-        speedFactors = camels.map(() => 0.85 + Math.random() * 0.3);
+        speedFactors = camels.map(() => 0.8 + Math.random() * 0.4);
+        if (Math.random() < 0.25) {
+          const favored = Math.floor(Math.random() * camels.length);
+          speedFactors[favored] += 0.5 + Math.random() * 0.4;
+        }
         updateTrackMetrics();
 
         raceInterval = setInterval(() => {
           let winner = null;
-          const backwardBaseChance = 0.15; // probabilidad base de ir hacia atrás
-          const backwardExtraChance = 0.1; // probabilidad extra si va muy adelantado
+          const backwardBaseChance = 0.1; // probabilidad base de ir hacia atrás
+          const backwardExtraChance = 0.2; // probabilidad extra si va muy adelantado
           camels.forEach((camel, i) => {
             const relativeProgress = positions[i] / trackWidth;
             const backwardChance = backwardBaseChance + (relativeProgress * backwardExtraChance);
-            const direction = Math.random() < backwardChance ? -1 : 1;
-            const randomness = 0.5 + Math.random() * 1.0; // entre 0.5 y 1.5
+            let direction = Math.random() < backwardChance ? -1 : 1;
+            let randomness = 0.4 + Math.random() * 1.6; // entre 0.4 y 2.0
+            const eventRoll = Math.random();
+            if (eventRoll < 0.05) {
+              direction = 1;
+              randomness *= 3;
+            } else if (eventRoll > 0.95) {
+              direction = -1;
+              randomness *= 3;
+            }
             positions[i] += speeds[i] * randomness * direction;
             if (positions[i] < 0) positions[i] = 0;
             camel.style.right = positions[i] + 'px';


### PR DESCRIPTION
## Summary
- Añade un factor de velocidad más variable para cada camello e introduce carreras amañadas aleatorias.
- Aumenta la aleatoriedad de los movimientos con sprints y tropiezos.
- Documenta que la carrera ahora puede favorecer o perjudicar a un camello al azar.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689254252ab88327a8ca3fd9fd477f5d